### PR TITLE
Add PR build validation without pushing images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [master]
+  pull_request:
   workflow_dispatch:
 
 env:
@@ -39,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -59,6 +61,6 @@ jobs:
         with:
           context: .
           platforms: linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- PR triggers build only (no image push)
- Master push triggers build and push to ghcr.io
- Saves storage on private repository

## Test plan
- [ ] PR workflow runs build successfully
- [ ] Master merge pushes image with `latest` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)