### PR TITLE
Add version command and --version CLI option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build with cross
         run: cross build --release --target aarch64-unknown-linux-gnu
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -55,6 +58,17 @@ jobs:
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build Docker image for verification
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test
+
+      - name: Verify version
+        run: docker run --rm --platform linux/arm64 ${{ env.IMAGE_NAME }}:test --version
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ thiserror = "2.0"
 # CLI
 clap = { version = "4", features = ["derive"] }
 
+# Version info
+vergen-gitcl = { version = "9.1", features = ["build", "cargo"] }
+const_format = "0.2"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Justfile
+++ b/Justfile
@@ -36,14 +36,14 @@ build:
     cargo build --release
 
 # Run the daemon
-run:
+run *args:
     @echo "Starting KGD daemon..."
-    cargo run --bin kgd
+    cargo run --bin kgd -- {{args}}
 
 # Run the daemon in release mode
-run-release:
+run-release *args:
     @echo "Starting KGD daemon (release mode)..."
-    cargo run --bin kgd --release
+    cargo run --bin kgd --release -- {{args}}
 
 # Clean build artifacts
 clean:

--- a/crates/kgd/Cargo.toml
+++ b/crates/kgd/Cargo.toml
@@ -25,3 +25,7 @@ tracing-subscriber = { workspace = true }
 surge-ping = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
+const_format = { workspace = true }
+
+[build-dependencies]
+vergen-gitcl = { workspace = true }

--- a/crates/kgd/build.rs
+++ b/crates/kgd/build.rs
@@ -1,0 +1,29 @@
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let build = BuildBuilder::default().build_date(true).build()?;
+    let cargo = CargoBuilder::default().target_triple(true).build()?;
+    let gitcl = GitclBuilder::default().sha(true).build()?;
+
+    let result = Emitter::default()
+        .add_instructions(&build)?
+        .add_instructions(&cargo)?
+        .add_instructions(&gitcl)?
+        .emit();
+
+    // git コマンドが失敗した場合、GITHUB_SHA 環境変数にフォールバック
+    if result.is_err() {
+        println!("cargo::rustc-env=VERGEN_BUILD_DATE=unknown");
+        println!("cargo::rustc-env=VERGEN_CARGO_TARGET_TRIPLE=unknown");
+        if let Ok(sha) = std::env::var("GITHUB_SHA") {
+            println!(
+                "cargo::rustc-env=VERGEN_GIT_SHA={}",
+                &sha[..7.min(sha.len())]
+            );
+        } else {
+            println!("cargo::rustc-env=VERGEN_GIT_SHA=unknown");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/kgd/src/main.rs
+++ b/crates/kgd/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod discord;
 mod ping;
 mod status;
+mod version;
 mod wol;
 
 use std::time::Duration;
@@ -14,6 +15,7 @@ use tokio::sync::mpsc;
 use tracing::info;
 
 #[derive(Parser)]
+#[command(version = version::short_version())]
 struct Args {
     #[arg(long, default_value = "config.toml")]
     config: PathBuf,

--- a/crates/kgd/src/version.rs
+++ b/crates/kgd/src/version.rs
@@ -1,0 +1,11 @@
+use const_format::formatcp;
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const GIT_SHA: &str = env!("VERGEN_GIT_SHA");
+pub const BUILD_DATE: &str = env!("VERGEN_BUILD_DATE");
+pub const TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
+
+/// clap の `--version` 用のバージョン文字列を返す。
+pub fn short_version() -> &'static str {
+    formatcp!("{VERSION} ({GIT_SHA} {BUILD_DATE})")
+}


### PR DESCRIPTION
## Summary
- `/version` Discord コマンドを追加（Version, Git SHA, Target, Build Date を表示）
- `--version` / `-V` CLI オプションを追加
- `just run` / `just run-release` に引数を渡せるように変更

Closes #6

## Test plan
- [ ] `just run --version` でバージョン情報が表示されることを確認
- [ ] Discord で `/version` コマンドが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)