### PR TITLE
feat: 日報のタイムゾーンを設定で指定可能に

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ humantime-serde = "1.1"
 
 # Date/Time
 chrono = "0.4"
+chrono-tz = "0.10"
 
 # Notion API
 notion-client = "1.0"

--- a/config.example.toml
+++ b/config.example.toml
@@ -66,3 +66,8 @@ forum_channel_id = 123456789012345678
 # Emoji reaction added to messages when synced successfully (default: ✅)
 # Use the actual Unicode emoji character, not the name
 # sync_reaction = "✅"
+
+# Timezone for diary date calculation (default: Asia/Tokyo)
+# Use IANA timezone names (e.g., "Asia/Tokyo", "America/New_York", "Europe/London", "UTC")
+# Full list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# timezone = "Asia/Tokyo"

--- a/crates/kgd/Cargo.toml
+++ b/crates/kgd/Cargo.toml
@@ -28,6 +28,7 @@ humantime.workspace = true
 humantime-serde.workspace = true
 const_format.workspace = true
 chrono.workspace = true
+chrono-tz.workspace = true
 notion-client.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true

--- a/crates/kgd/src/config.rs
+++ b/crates/kgd/src/config.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::Path, time::Duration};
 
 use anyhow::{Context as _, Result};
+use chrono_tz::Tz;
 use macaddr::MacAddr6;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -109,6 +110,7 @@ fn default_interval() -> Duration {
 }
 
 /// 日報機能の設定。
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct DiaryConfig {
     /// PostgreSQL データベース URL
@@ -128,6 +130,10 @@ pub struct DiaryConfig {
     /// 同期成功時にメッセージに付けるリアクション絵文字
     #[serde(default = "default_sync_reaction")]
     pub sync_reaction: String,
+    /// 日報の日付計算に使用するタイムゾーン（デフォルト: Asia/Tokyo）
+    #[serde(default = "default_timezone")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub timezone: Tz,
 }
 
 /// Notion タグ設定。
@@ -148,6 +154,10 @@ fn default_title_property() -> String {
 
 fn default_sync_reaction() -> String {
     "✅".to_string()
+}
+
+fn default_timezone() -> Tz {
+    chrono_tz::Asia::Tokyo
 }
 
 #[cfg(test)]
@@ -188,6 +198,7 @@ mod tests {
                 notion_tags: vec![],
                 forum_channel_id: 123456789012345678,
                 sync_reaction: "✅".to_string(),
+                timezone: chrono_tz::Asia::Tokyo,
             },
         };
 

--- a/crates/kgd/src/diary/mod.rs
+++ b/crates/kgd/src/diary/mod.rs
@@ -11,9 +11,19 @@ pub use notion::NotionClient;
 pub use store::{DiaryEntry, DiaryStore, MessageBlock};
 pub use sync::MessageSyncer;
 
-use chrono::{DateTime, Local, NaiveTime, Utc};
+use chrono::{DateTime, NaiveTime, Utc};
+use chrono_tz::Tz;
 
-/// 現在のローカル日付の開始時刻（00:00:00）を UTC で取得する。
-pub fn today_local() -> DateTime<Utc> {
-    Local::now().with_time(NaiveTime::MIN).unwrap().to_utc()
+/// 指定されたタイムゾーンでの現在の日付の開始時刻（00:00:00）を UTC で取得する。
+pub fn today_in_timezone(tz: &Tz) -> DateTime<Utc> {
+    Utc::now()
+        .with_timezone(tz)
+        .with_time(NaiveTime::MIN)
+        .unwrap()
+        .to_utc()
+}
+
+/// 指定されたタイムゾーンでの日付を "YYYY-MM-DD" 形式の文字列として取得する。
+pub fn format_date_in_timezone(date: DateTime<Utc>, tz: &Tz) -> String {
+    date.with_timezone(tz).format("%Y-%m-%d").to_string()
 }


### PR DESCRIPTION
## Summary
- 日報機能で使用するタイムゾーンを設定ファイルで指定できるようにした
- デフォルトは `Asia/Tokyo` で、IANA形式のタイムゾーン名（例: `America/New_York`, `Europe/London`, `UTC`）をサポート
- コンテナ環境などでシステムタイムゾーンがUTCの場合でも正しい日付で日報を作成可能

## Changes
- `chrono-tz` クレートを追加
- `DiaryConfig` に `timezone` フィールドを追加
- `today_local()` を `today_in_timezone()` に変更し、設定されたタイムゾーンを使用

## 設定例
```toml
[diary]
# ...
timezone = "Asia/Tokyo"  # デフォルト値
```

Closes #25

## Test plan
- [x] `just validate` が通ることを確認
- [x] `just test` が通ることを確認
- [x] timezone を指定しない場合、デフォルトで Asia/Tokyo が使用されることを確認
- [x] timezone を UTC や他のタイムゾーンに変更した場合、日付が正しく計算されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)