### PR TITLE
feat: メッセージのフォーマットを Handlebars テンプレートで設定可能に

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ reqwest = { version = "0.12", features = ["json", "multipart"] }
 # JSON serialization
 serde_json = "1.0"
 
+# Templating
+handlebars = "6.3"
+
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "migrate"] }
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -71,3 +71,14 @@ forum_channel_id = 123456789012345678
 # Use IANA timezone names (e.g., "Asia/Tokyo", "America/New_York", "Europe/London", "UTC")
 # Full list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # timezone = "Asia/Tokyo"
+
+# Message template (Handlebars format, default: "{{content}}")
+# Available variables:
+#   - content: Message text
+#   - author: Author's username
+#   - timestamp: Message timestamp (ISO 8601 format)
+# Examples:
+#   message_template = "{{content}}"
+#   message_template = "{{author}}: {{content}}"
+#   message_template = "[{{timestamp}}] {{content}}"
+# message_template = "{{content}}"

--- a/crates/kgd/Cargo.toml
+++ b/crates/kgd/Cargo.toml
@@ -32,6 +32,7 @@ chrono-tz.workspace = true
 notion-client.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
+handlebars.workspace = true
 sqlx.workspace = true
 openssl.workspace = true
 

--- a/crates/kgd/src/config.rs
+++ b/crates/kgd/src/config.rs
@@ -134,6 +134,11 @@ pub struct DiaryConfig {
     #[serde(default = "default_timezone")]
     #[serde_as(as = "DisplayFromStr")]
     pub timezone: Tz,
+    /// メッセージ本文のフォーマットテンプレート（Handlebars 形式）
+    /// 使用可能な変数: content (メッセージ本文), author (投稿者名), timestamp (投稿日時)
+    /// デフォルト: "{{content}}" (メッセージ本文をそのまま使用)
+    #[serde(default = "default_message_template")]
+    pub message_template: String,
 }
 
 /// Notion タグ設定。
@@ -158,6 +163,10 @@ fn default_sync_reaction() -> String {
 
 fn default_timezone() -> Tz {
     chrono_tz::Asia::Tokyo
+}
+
+fn default_message_template() -> String {
+    "{{content}}".to_string()
 }
 
 #[cfg(test)]
@@ -199,6 +208,7 @@ mod tests {
                 forum_channel_id: 123456789012345678,
                 sync_reaction: "✅".to_string(),
                 timezone: chrono_tz::Asia::Tokyo,
+                message_template: "{{content}}".to_string(),
             },
         };
 

--- a/crates/kgd/src/discord.rs
+++ b/crates/kgd/src/discord.rs
@@ -144,7 +144,11 @@ impl EventHandler for Handler {
         let page_id = entry.page_id.clone();
 
         // Notion に同期
-        let syncer = MessageSyncer::new(self.notion_client.as_ref(), &self.diary_store);
+        let syncer = MessageSyncer::new(
+            self.notion_client.as_ref(),
+            &self.diary_store,
+            &self.config.diary.message_template,
+        );
         match syncer.sync_message(&page_id, &message).await {
             Ok(result) if result.synced => {
                 info!(
@@ -210,7 +214,11 @@ impl EventHandler for Handler {
         let mut message = message;
         message.content = content;
 
-        let syncer = MessageSyncer::new(self.notion_client.as_ref(), &self.diary_store);
+        let syncer = MessageSyncer::new(
+            self.notion_client.as_ref(),
+            &self.diary_store,
+            &self.config.diary.message_template,
+        );
         match syncer.update_message(&message).await {
             Ok(true) => {
                 info!(
@@ -252,7 +260,11 @@ impl EventHandler for Handler {
         };
 
         // Notion から対応するブロックを削除
-        let syncer = MessageSyncer::new(self.notion_client.as_ref(), &self.diary_store);
+        let syncer = MessageSyncer::new(
+            self.notion_client.as_ref(),
+            &self.diary_store,
+            &self.config.diary.message_template,
+        );
         match syncer.delete_message(deleted_message_id.get()).await {
             Ok(true) => {
                 info!(


### PR DESCRIPTION
## Summary
- DiaryConfig に `message_template` 設定を追加
- Discord メッセージを Notion に同期する際のフォーマットを Handlebars テンプレートでカスタマイズ可能に
- 使用可能な変数: `content` (メッセージ本文), `author` (投稿者名), `timestamp` (投稿日時)

## Test plan
- [x] `just validate` が通ることを確認
- [x] `just test` が通ることを確認
- [x] `just deny` と `just machete` が通ることを確認
- [x] デフォルトテンプレート (`{{content}}`) で従来通りの動作を確認
- [x] カスタムテンプレート (例: `{{author}}: {{content}}`) で期待通りフォーマットされることを確認

closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)