### PR TITLE
feat: 日報スレッドの自動クローズ機能を実装

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -76,6 +76,18 @@ forum_channel_id = 123456789012345678
 # Supported types: link (inline link in text), bookmark, embed
 # default_convert_to = ["link"]
 
+# Auto-close feature for diary threads (default: disabled)
+# When enabled, the bot will send a button message to old diary threads
+# auto_close_enabled = false
+
+# Hour of the day (0-23) when auto-close button should be sent (default: 8)
+# The button will only be sent after this hour in the configured timezone
+# auto_close_hour = 8
+
+# Interval for checking threads that need auto-close (default: 1h)
+# Format: "30s", "5m", "1h", "2h", etc.
+# auto_close_interval = "1h"
+
 # URL conversion rules
 # URLs matching a pattern will be converted to the specified types.
 # Supported types: link (inline link in text), bookmark, embed

--- a/crates/kgd/src/config.rs
+++ b/crates/kgd/src/config.rs
@@ -141,6 +141,15 @@ pub struct DiaryConfig {
     /// どのルールにもマッチしなかった URL に適用するデフォルトの変換（デフォルト: ["link"]）
     #[serde(default = "default_convert_to")]
     pub default_convert_to: Vec<String>,
+    /// 自動クローズ機能を有効にするか（デフォルト: false）
+    #[serde(default)]
+    pub auto_close_enabled: bool,
+    /// 自動クローズの確認メッセージを送信する時刻（時）（デフォルト: 8）
+    #[serde(default = "default_auto_close_hour")]
+    pub auto_close_hour: u32,
+    /// 自動クローズのチェック間隔（デフォルト: 1時間）
+    #[serde(default = "default_auto_close_interval", with = "humantime_serde")]
+    pub auto_close_interval: Duration,
 }
 
 /// URL 変換ルール設定。
@@ -198,6 +207,14 @@ fn default_convert_to() -> Vec<String> {
     vec!["link".to_string()]
 }
 
+fn default_auto_close_hour() -> u32 {
+    8
+}
+
+fn default_auto_close_interval() -> Duration {
+    Duration::from_secs(3600) // 1 hour
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,6 +256,9 @@ mod tests {
                 timezone: chrono_tz::Asia::Tokyo,
                 url_rules: vec![],
                 default_convert_to: vec!["link".to_string()],
+                auto_close_enabled: false,
+                auto_close_hour: 8,
+                auto_close_interval: Duration::from_secs(3600),
             },
         };
 

--- a/crates/kgd/src/diary/store.rs
+++ b/crates/kgd/src/diary/store.rs
@@ -165,4 +165,18 @@ impl DiaryStore {
 
         Ok(())
     }
+
+    /// すべての日報エントリを取得する。
+    pub async fn get_all_entries(&self) -> Result<Vec<DiaryEntry>> {
+        sqlx::query_as(
+            r#"
+            SELECT thread_id, page_id, page_url, date, created_at
+            FROM diary_entries
+            ORDER BY date DESC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .context("Failed to fetch all diary entries")
+    }
 }


### PR DESCRIPTION
## Summary

Issue #29 の対応として、日報スレッドの自動クローズ機能を実装しました。

- 日付が変わって指定時刻（デフォルト: 8時）以降になると、古い日報スレッドにボタン付きメッセージを送信
- ボタンをクリックすると、現在のスレッドをクローズし、新しい日付の日報スレッドを自動作成
- 定期的にチェックするバックグラウンドタスクを実装

## 主な変更点

### 設定追加
- `auto_close_enabled`: 自動クローズ機能の有効/無効（デフォルト: false）
- `auto_close_hour`: ボタンを送信する時刻（時、デフォルト: 8）
- `auto_close_interval`: チェック間隔（デフォルト: 1時間）

### 実装内容
- [config.rs:144-152](crates/kgd/src/config.rs#L144-L152): 設定構造体に自動クローズ関連フィールドを追加
- [store.rs:172-183](crates/kgd/src/diary/store.rs#L172-L183): `get_all_entries` メソッドを追加
- [discord.rs:628-801](crates/kgd/src/discord.rs#L628-L801): 自動クローズ関連のメソッドを実装
  - `handle_diary_close_and_new`: ボタンクリック時の処理
  - `check_auto_close`: 自動クローズチェック
  - `send_auto_close_button`: ボタン付きメッセージ送信
- [discord.rs:104-138](crates/kgd/src/discord.rs#L104-L138): Component インタラクションのハンドリング
- [discord.rs:893-905](crates/kgd/src/discord.rs#L893-L905): 自動クローズチェックタスクの起動

## 動作フロー

1. `/diary new` で日報スレッドが作成される（2026-01-01）
2. 定期的にバックグラウンドタスクが古いスレッドをチェック
3. 2026-01-02 8:00 JST 以降に、2026-01-01 のスレッドにボタン付きメッセージを送信
4. ユーザーがボタンをクリック:
   - 2026-01-01 スレッドをクローズ（アーカイブ＋ロック）
   - 2026-01-02 スレッドを新規作成し、メンション

## Test plan

- [ ] 設定で `auto_close_enabled = true` を有効化
- [ ] `/diary new` で日報スレッドを作成
- [ ] 日付を過去に変更してテスト、またはチェック間隔を短くしてテスト
- [ ] ボタン付きメッセージが送信されることを確認
- [ ] ボタンをクリックして、スレッドがクローズされ新しいスレッドが作成されることを確認
- [ ] Notion ページが正しく作成または再利用されることを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)