### PR TITLE
fix: ローカル開発用にDebianベースのランタイムを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,29 @@ COPY . .
 
 RUN cargo build --release --bin kgd
 
-# 共通ランタイムベース
+# ローカル開発用ランタイムベース
+# builder ステージ (rust:bookworm/Debian 12) と libjpeg のバージョンを合わせるため Debian を使用
+FROM debian:bookworm-slim AS runtime-base-local
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libcap2-bin \
+    # libheif の実行時依存ライブラリ
+    libde265-0 \
+    libx265-199 \
+    libaom3 \
+    libwebp7 \
+    zlib1g \
+    libjpeg62-turbo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -r -s /bin/false kgd
+
+WORKDIR /app
+
+# CI/本番用ランタイムベース
 # cross-rs のビルド環境 (Ubuntu 22.04) と libjpeg のバージョンを合わせるため Ubuntu を使用
-FROM ubuntu:22.04 AS runtime-base
+FROM ubuntu:22.04 AS runtime-base-ci
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -45,7 +65,7 @@ WORKDIR /app
 
 # ローカル開発用 (--target local)
 # builder ステージでビルドしたバイナリを使用する
-FROM runtime-base AS local
+FROM runtime-base-local AS local
 
 COPY --from=builder /app/target/release/kgd /app/kgd
 
@@ -57,7 +77,7 @@ ENTRYPOINT ["/app/kgd"]
 
 # CI/本番用 (デフォルトターゲット)
 # cross-rs でビルド済みのバイナリをホストからコピーする
-FROM runtime-base
+FROM runtime-base-ci
 
 ARG CROSS_TARGET=aarch64-unknown-linux-gnu
 COPY target/${CROSS_TARGET}/release/kgd /app/kgd


### PR DESCRIPTION
## Summary
- ローカル開発用 (`--target local`) と CI/本番用でランタイムベースを分離
- `runtime-base-local`: Debian bookworm-slim (`libjpeg62-turbo`) - builder ステージと libjpeg バージョンを合わせる
- `runtime-base-ci`: Ubuntu 22.04 (`libjpeg-turbo8`) - cross-rs のビルド環境と libjpeg バージョンを合わせる

## 原因
builder ステージ (`rust:bookworm` = Debian 12) でビルドされたバイナリは `libjpeg62-turbo` (`libjpeg.so.62`) にリンクされるが、元のランタイム (Ubuntu 22.04) は `libjpeg-turbo8` (`libjpeg.so.8`) を提供するため、以下のエラーが発生していた:
```
/app/kgd: error while loading shared libraries: libjpeg.so.62: cannot open shared object file: No such file or directory
```

Ubuntu 22.04 には `libjpeg62` パッケージが存在するが、これは古い IJG JPEG 6b の実装であり、libheif が必要とする `jpeg_mem_src` / `jpeg_mem_dest` 関数が含まれていないためビルドに失敗する。そのため、ローカル開発用には Debian bookworm ベースのランタイムを使用する必要がある。

## Test plan
- [x] `docker build --target local` が成功すること
- [x] ビルドしたイメージで `ldd /app/kgd` を実行し、`libjpeg.so.62` が正しく見つかること

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)