### PR TITLE
Notionのブックマークに OGP メタデータを埋め込む

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arbitrary"
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1065,6 +1065,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1501,7 +1502,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1839,6 +1840,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "const_format",
+ "futures",
  "glob-match",
  "heif",
  "humantime",
@@ -2831,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2843,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2854,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -2943,7 +2945,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3872,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3895,9 +3897,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4546,14 +4548,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4934,18 +4936,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ glob-match = "0.2"
 # Image processing
 image = "0.25"
 
+# Async utilities
+futures = "0.3"
+
 # Testing
 tempfile = "3.14"
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -88,6 +88,15 @@ forum_channel_id = 123456789012345678
 # Format: "30s", "5m", "1h", "2h", etc.
 # auto_close_interval = "1h"
 
+# OGP metadata fetching for bookmark blocks (default: enabled)
+# When enabled, the bot will fetch Open Graph metadata (title, description)
+# from bookmarked URLs and add them as captions in Notion.
+# ogp_enabled = true
+
+# Timeout for OGP metadata fetching (default: 10s)
+# Format: "5s", "10s", "30s", etc.
+# ogp_timeout = "10s"
+
 # URL conversion rules
 # URLs matching a pattern will be converted to the specified types.
 # Supported types: link (inline link in text), bookmark, embed

--- a/crates/kgd/Cargo.toml
+++ b/crates/kgd/Cargo.toml
@@ -34,6 +34,7 @@ openssl.workspace = true
 mime_guess.workspace = true
 regex.workspace = true
 glob-match.workspace = true
+futures.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 heif.path = "../heif"

--- a/crates/kgd/src/config.rs
+++ b/crates/kgd/src/config.rs
@@ -150,6 +150,12 @@ pub struct DiaryConfig {
     /// 自動クローズのチェック間隔（デフォルト: 1時間）
     #[serde(default = "default_auto_close_interval", with = "humantime_serde")]
     pub auto_close_interval: Duration,
+    /// OGP メタデータ取得を有効にするか（デフォルト: true）
+    #[serde(default = "default_ogp_enabled")]
+    pub ogp_enabled: bool,
+    /// OGP メタデータ取得のタイムアウト（デフォルト: 10秒）
+    #[serde(default = "default_ogp_timeout", with = "humantime_serde")]
+    pub ogp_timeout: Duration,
 }
 
 /// URL 変換ルール設定。
@@ -215,6 +221,14 @@ fn default_auto_close_interval() -> Duration {
     Duration::from_secs(3600) // 1 hour
 }
 
+fn default_ogp_enabled() -> bool {
+    true
+}
+
+fn default_ogp_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,6 +273,8 @@ mod tests {
                 auto_close_enabled: false,
                 auto_close_hour: 8,
                 auto_close_interval: Duration::from_secs(3600),
+                ogp_enabled: true,
+                ogp_timeout: Duration::from_secs(10),
             },
         };
 

--- a/crates/kgd/src/diary/mod.rs
+++ b/crates/kgd/src/diary/mod.rs
@@ -4,6 +4,7 @@
 //! メッセージの同期とライフサイクル管理を行う。
 
 mod notion;
+mod ogp;
 mod store;
 mod sync;
 mod url_parser;

--- a/crates/kgd/src/diary/ogp.rs
+++ b/crates/kgd/src/diary/ogp.rs
@@ -1,0 +1,363 @@
+//! OGP メタデータの取得機能を提供する。
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use regex::Regex;
+
+/// OGP メタデータ。
+#[derive(Debug, Clone, Default)]
+pub struct OgpMetadata {
+    /// og:title - ページタイトル
+    pub title: Option<String>,
+    /// og:description - ページ説明
+    pub description: Option<String>,
+}
+
+/// OGP メタデータを取得するクライアント。
+pub struct OgpFetcher {
+    http_client: reqwest::Client,
+}
+
+impl OgpFetcher {
+    /// 新しい OgpFetcher を作成する。
+    pub fn new(timeout: Duration) -> Result<Self> {
+        let http_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .user_agent("kgd-bot/1.0")
+            .build()
+            .context("Failed to create HTTP client for OGP fetcher")?;
+
+        Ok(Self { http_client })
+    }
+
+    /// URL から OGP メタデータを取得する。
+    ///
+    /// 取得に失敗した場合は None を返す（エラーはログに記録）。
+    pub async fn fetch(&self, url: &str) -> Option<OgpMetadata> {
+        match self.fetch_inner(url).await {
+            Ok(metadata) => Some(metadata),
+            Err(e) => {
+                tracing::debug!(url = %url, error = %e, "Failed to fetch OGP metadata");
+                None
+            }
+        }
+    }
+
+    /// 複数の URL から OGP メタデータを並列で取得する。
+    pub async fn fetch_many(&self, urls: &[String]) -> HashMap<String, OgpMetadata> {
+        let futures: Vec<_> = urls
+            .iter()
+            .map(|url| async {
+                let metadata = self.fetch(url).await;
+                (url.clone(), metadata)
+            })
+            .collect();
+
+        futures::future::join_all(futures)
+            .await
+            .into_iter()
+            .filter_map(|(url, ogp)| ogp.map(|o| (url, o)))
+            .collect()
+    }
+
+    async fn fetch_inner(&self, url: &str) -> Result<OgpMetadata> {
+        let response = self
+            .http_client
+            .get(url)
+            .send()
+            .await
+            .context("HTTP request failed")?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("HTTP status: {}", response.status());
+        }
+
+        let html = response
+            .text()
+            .await
+            .context("Failed to read response body")?;
+
+        Ok(parse_ogp_metadata(&html))
+    }
+}
+
+/// HTML から OGP メタデータをパースする。
+///
+/// 正規表現を使用して meta タグから OGP 情報を抽出する。
+fn parse_ogp_metadata(html: &str) -> OgpMetadata {
+    let mut metadata = OgpMetadata::default();
+
+    // og:title
+    if let Some(value) = extract_meta_property(html, "og:title") {
+        metadata.title = Some(value);
+    }
+
+    // og:description
+    if let Some(value) = extract_meta_property(html, "og:description") {
+        metadata.description = Some(value);
+    }
+
+    // フォールバック: <title> タグ
+    if metadata.title.is_none()
+        && let Some(value) = extract_title_tag(html)
+    {
+        metadata.title = Some(value);
+    }
+
+    // フォールバック: description meta タグ
+    if metadata.description.is_none()
+        && let Some(value) = extract_meta_name(html, "description")
+    {
+        metadata.description = Some(value);
+    }
+
+    metadata
+}
+
+/// property 属性で指定された meta タグの content を抽出する。
+fn extract_meta_property(html: &str, property: &str) -> Option<String> {
+    // <meta property="og:title" content="..."> または
+    // <meta content="..." property="og:title"> のパターンに対応
+    let pattern = format!(
+        r#"<meta\s+(?:[^>]*?\s+)?property\s*=\s*["']{}["']\s+(?:[^>]*?\s+)?content\s*=\s*["']([^"']*)["']|<meta\s+(?:[^>]*?\s+)?content\s*=\s*["']([^"']*)["']\s+(?:[^>]*?\s+)?property\s*=\s*["']{}["']"#,
+        regex::escape(property),
+        regex::escape(property)
+    );
+    let re = Regex::new(&pattern).ok()?;
+
+    if let Some(caps) = re.captures(html) {
+        let content = caps.get(1).or_else(|| caps.get(2))?.as_str();
+        let content = decode_html_entities(content.trim());
+        if !content.is_empty() {
+            return Some(content);
+        }
+    }
+    None
+}
+
+/// name 属性で指定された meta タグの content を抽出する。
+fn extract_meta_name(html: &str, name: &str) -> Option<String> {
+    // <meta name="description" content="..."> または
+    // <meta content="..." name="description"> のパターンに対応
+    let pattern = format!(
+        r#"<meta\s+(?:[^>]*?\s+)?name\s*=\s*["']{}["']\s+(?:[^>]*?\s+)?content\s*=\s*["']([^"']*)["']|<meta\s+(?:[^>]*?\s+)?content\s*=\s*["']([^"']*)["']\s+(?:[^>]*?\s+)?name\s*=\s*["']{}["']"#,
+        regex::escape(name),
+        regex::escape(name)
+    );
+    let re = Regex::new(&pattern).ok()?;
+
+    if let Some(caps) = re.captures(html) {
+        let content = caps.get(1).or_else(|| caps.get(2))?.as_str();
+        let content = decode_html_entities(content.trim());
+        if !content.is_empty() {
+            return Some(content);
+        }
+    }
+    None
+}
+
+/// <title> タグの内容を抽出する。
+fn extract_title_tag(html: &str) -> Option<String> {
+    let re = Regex::new(r"<title[^>]*>([^<]*)</title>").ok()?;
+
+    if let Some(caps) = re.captures(html) {
+        let title = caps.get(1)?.as_str();
+        let title = decode_html_entities(title.trim());
+        if !title.is_empty() {
+            return Some(title);
+        }
+    }
+    None
+}
+
+/// 基本的な HTML エンティティをデコードする。
+fn decode_html_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&#x27;", "'")
+        .replace("&nbsp;", " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ogp_metadata_full() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta property="og:title" content="Test Title">
+                <meta property="og:description" content="Test Description">
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("Test Title".to_string()));
+        assert_eq!(metadata.description, Some("Test Description".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_content_first() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta content="Title Content First" property="og:title">
+                <meta content="Description Content First" property="og:description">
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("Title Content First".to_string()));
+        assert_eq!(
+            metadata.description,
+            Some("Description Content First".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_fallback_to_title_tag() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>Fallback Title</title>
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("Fallback Title".to_string()));
+        assert_eq!(metadata.description, None);
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_fallback_to_meta_description() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta property="og:title" content="OGP Title">
+                <meta name="description" content="Meta Description">
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("OGP Title".to_string()));
+        assert_eq!(metadata.description, Some("Meta Description".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_og_description_takes_priority() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta property="og:description" content="OGP Description">
+                <meta name="description" content="Meta Description">
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.description, Some("OGP Description".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_empty_values_ignored() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta property="og:title" content="">
+                <meta property="og:description" content="   ">
+                <title>Fallback Title</title>
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("Fallback Title".to_string()));
+        assert_eq!(metadata.description, None);
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_whitespace_trimmed() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta property="og:title" content="  Trimmed Title  ">
+                <meta property="og:description" content="  Trimmed Description  ">
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("Trimmed Title".to_string()));
+        assert_eq!(
+            metadata.description,
+            Some("Trimmed Description".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_no_metadata() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head></head>
+            <body>Hello</body>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, None);
+        assert_eq!(metadata.description, None);
+    }
+
+    #[test]
+    fn test_parse_ogp_metadata_html_entities_decoded() {
+        let html = r#"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta property="og:title" content="Title &amp; More">
+                <meta property="og:description" content="&lt;Test&gt; &quot;Description&quot;">
+            </head>
+            </html>
+        "#;
+
+        let metadata = parse_ogp_metadata(html);
+        assert_eq!(metadata.title, Some("Title & More".to_string()));
+        assert_eq!(
+            metadata.description,
+            Some("<Test> \"Description\"".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_title_tag() {
+        assert_eq!(
+            extract_title_tag("<title>Test</title>"),
+            Some("Test".to_string())
+        );
+        assert_eq!(
+            extract_title_tag("<title>  Trimmed  </title>"),
+            Some("Trimmed".to_string())
+        );
+        assert_eq!(extract_title_tag("<title></title>"), None);
+        assert_eq!(extract_title_tag("<p>No title</p>"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Discord 日報スレッドに投稿された URL から OGP メタデータ（タイトル、説明）を取得
- ブックマークブロックのキャプションとして埋め込む機能を追加
- 複数 URL の並列取得に対応
- `ogp_enabled`, `ogp_timeout` で設定可能

## Changes
- `crates/kgd/src/diary/ogp.rs`: OGP メタデータ取得モジュール（正規表現ベース）
- `crates/kgd/src/diary/url_parser.rs`: bookmark_urls の収集と apply_ogp_to_bookmark 関数
- `crates/kgd/src/diary/sync.rs`: OGP 取得の統合
- `crates/kgd/src/config.rs`: ogp_enabled, ogp_timeout 設定オプション

## Test plan
- [x] `just ci` が通ることを確認
- [x] Discord 日報スレッドに URL を投稿して Notion でキャプションが表示されることを確認

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)