### PR TITLE
最新の日報スレッドのみにクローズボタンを表示する

### DIFF
--- a/crates/kgd/src/diary/store.rs
+++ b/crates/kgd/src/diary/store.rs
@@ -166,17 +166,18 @@ impl DiaryStore {
         Ok(())
     }
 
-    /// すべての日報エントリを取得する。
-    pub async fn get_all_entries(&self) -> Result<Vec<DiaryEntry>> {
+    /// 最新の日報エントリを取得する。
+    pub async fn get_latest_entry(&self) -> Result<Option<DiaryEntry>> {
         sqlx::query_as(
             r#"
             SELECT thread_id, page_id, page_url, date, created_at
             FROM diary_entries
             ORDER BY date DESC
+            LIMIT 1
             "#,
         )
-        .fetch_all(&self.pool)
+        .fetch_optional(&self.pool)
         .await
-        .context("Failed to fetch all diary entries")
+        .context("Failed to fetch latest diary entry")
     }
 }


### PR DESCRIPTION
## Summary

- 自動クローズのボタン送信対象を全スレッドから**最新の1件のみ**に変更し、通知が繰り返される問題を解消
- スレッド作成時の初期メッセージにもクローズ&新規作成ボタンを追加
- ボタン作成ロジックを共通関数 `create_close_and_new_action_row` に切り出し

Closes #46

## Test plan

- [ ] `just validate` が通ること (fmt, check, clippy)
- [ ] `just test` が通ること (60 tests passed)
- [ ] 自動クローズボタンが最新のスレッドにのみ送信されることを確認
- [ ] 新規スレッド作成時に初期メッセージにクローズボタンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)