### PR TITLE
日報スレッドの最新判定とスターターボタン周りを改善

### DIFF
--- a/crates/kgd/src/discord.rs
+++ b/crates/kgd/src/discord.rs
@@ -515,9 +515,7 @@ impl Handler {
 
         // Discord フォーラムにスレッドを作成
         let forum_channel = ChannelId::new(diary_config.forum_channel_id);
-        let initial_message = CreateMessage::new()
-            .content(format!("Notion: {}", page_url))
-            .components(vec![create_close_and_new_action_row()]);
+        let initial_message = create_diary_thread_initial_message(&page_url);
         let forum_post = CreateForumPost::new(date_str, initial_message);
 
         let thread = forum_channel
@@ -693,7 +691,7 @@ impl Handler {
 
         // Discord スレッドを作成
         let forum_channel_id = ChannelId::new(self.config.diary.forum_channel_id);
-        let initial_message = CreateMessage::new().content(&page_url);
+        let initial_message = create_diary_thread_initial_message(&page_url);
         let forum_post = CreateForumPost::new(date_str, initial_message);
         let thread = forum_channel_id
             .create_forum_post(&ctx.http, forum_post)
@@ -800,6 +798,13 @@ fn create_close_and_new_action_row() -> CreateActionRow {
         .label("クローズして新しい日報を作成")
         .style(serenity::all::ButtonStyle::Primary);
     CreateActionRow::Buttons(vec![button])
+}
+
+/// 日報スレッドの最初のメッセージを構築する。
+fn create_diary_thread_initial_message(page_url: &str) -> CreateMessage {
+    CreateMessage::new()
+        .content(format!("Notion: {}", page_url))
+        .components(vec![create_close_and_new_action_row()])
 }
 
 /// サーバーステータスをDiscordチャンネルに通知するための構造体。

--- a/crates/kgd/src/discord.rs
+++ b/crates/kgd/src/discord.rs
@@ -6,9 +6,9 @@ use serenity::{
     all::{
         ActionRowComponent, ButtonKind, ChannelId, ChannelType, CommandInteraction,
         ComponentInteraction, CreateActionRow, CreateButton, CreateCommand, CreateCommandOption,
-        CreateEmbed, CreateForumPost, CreateInteractionResponse,
-        CreateInteractionResponseMessage, CreateMessage, EditThread, GatewayIntents, GetMessages,
-        Http, Message, MessageUpdateEvent, ReactionType,
+        CreateEmbed, CreateForumPost, CreateInteractionResponse, CreateInteractionResponseMessage,
+        CreateMessage, EditThread, GatewayIntents, GetMessages, Http, Message, MessageUpdateEvent,
+        ReactionType,
     },
     async_trait,
     builder::CreateEmbedFooter,
@@ -473,23 +473,55 @@ impl Handler {
         if let Some(entry) = self.diary_store.get_by_date(date).await? {
             let thread_id = ChannelId::new(entry.thread_id);
 
-            // スレッドのロックを解除して再開
-            let edit = EditThread::new().archived(false).locked(false);
-            thread_id
-                .edit_thread(&ctx.http, edit)
-                .await
-                .context("スレッドのロック解除に失敗しました")?;
+            let reopened = match thread_id.join_thread(&ctx.http).await {
+                Ok(()) => {
+                    let edit = EditThread::new().archived(false).locked(false);
+                    match thread_id.edit_thread(&ctx.http, edit).await {
+                        Ok(_) => true,
+                        Err(error) => {
+                            warn!(
+                                error = %error,
+                                thread_id = entry.thread_id,
+                                "Failed to reopen existing diary thread; falling back to link only"
+                            );
+                            false
+                        }
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        thread_id = entry.thread_id,
+                        "Failed to join existing diary thread; falling back to link only"
+                    );
+                    false
+                }
+            };
 
-            self.ensure_close_and_new_button(&ctx.http, thread_id).await?;
+            if let Err(error) = self.ensure_close_and_new_button(&ctx.http, thread_id).await {
+                warn!(
+                    error = %error,
+                    thread_id = entry.thread_id,
+                    "Failed to ensure close button on existing diary thread"
+                );
+            }
 
             info!(
                 date = %date,
                 thread_id = entry.thread_id,
-                "Diary thread reopened"
+                reopened,
+                "Diary thread already exists for today"
             );
 
             let response = CreateInteractionResponseMessage::new()
-                .content(format!("今日の日報を再開しました: <#{}>", entry.thread_id))
+                .content(if reopened {
+                    format!("今日の日報を再開しました: <#{}>", entry.thread_id)
+                } else {
+                    format!(
+                        "今日の日報は既にありますが、再開はできません: <#{}>",
+                        entry.thread_id
+                    )
+                })
                 .ephemeral(false);
             command
                 .create_response(&ctx.http, CreateInteractionResponse::Message(response))
@@ -529,7 +561,8 @@ impl Handler {
             .context("フォーラムスレッドの作成に失敗しました")?;
 
         // 紐付け情報を保存
-        self.ensure_close_and_new_button(&ctx.http, thread.id).await?;
+        self.ensure_close_and_new_button(&ctx.http, thread.id)
+            .await?;
 
         let entry = DiaryEntry {
             thread_id: thread.id.get(),
@@ -651,13 +684,33 @@ impl Handler {
         ctx: &SerenityContext,
         component: &ComponentInteraction,
     ) -> Result<()> {
-        // 該当スレッドの日報エントリを取得
         let channel_id = component.channel_id;
         let Some(_entry) = self.diary_store.get_by_thread(channel_id.get()).await? else {
             anyhow::bail!("このスレッドは日報スレッドではありません");
         };
 
-        // 先にレスポンスを返す
+        let timezone = &self.config.diary.timezone;
+        let today = today_in_timezone(timezone);
+        if let Some(today_entry) = self.diary_store.get_by_date(today).await? {
+            let response = if today_entry.thread_id == channel_id.get() {
+                CreateInteractionResponseMessage::new()
+                    .content("このスレッドが今日の最新の日報です")
+                    .ephemeral(false)
+            } else {
+                CreateInteractionResponseMessage::new()
+                    .content(format!(
+                        "今日の最新の日報はこちらです: <#{}>",
+                        today_entry.thread_id
+                    ))
+                    .ephemeral(false)
+            };
+
+            component
+                .create_response(&ctx.http, CreateInteractionResponse::Message(response))
+                .await?;
+            return Ok(());
+        }
+
         let response = CreateInteractionResponseMessage::new()
             .content("日報スレッドをクローズして新しいスレッドを作成しています...")
             .ephemeral(false);
@@ -666,24 +719,10 @@ impl Handler {
             .create_response(&ctx.http, CreateInteractionResponse::Message(response))
             .await?;
 
-        // 現在のスレッドをクローズ
-        let edit = EditThread::new().archived(true).locked(true);
-        channel_id
-            .edit_thread(&ctx.http, edit)
-            .await
-            .context("スレッドのクローズに失敗しました")?;
-
-        info!(
-            thread_id = channel_id.get(),
-            "Diary thread closed by button"
-        );
-
-        // 新しい日報スレッドを作成
         let timezone = &self.config.diary.timezone;
         let today = today_in_timezone(timezone);
         let date_str = format_date_in_timezone(today, timezone);
 
-        // Notion ページを検索
         let notion_client = self.notion_client.as_ref();
         let (page_id, page_url) = match notion_client.find_diary_page_by_title(&date_str).await? {
             Some((page_id, page_url)) => {
@@ -696,7 +735,6 @@ impl Handler {
             }
         };
 
-        // Discord スレッドを作成
         let forum_channel_id = ChannelId::new(self.config.diary.forum_channel_id);
         let initial_message = create_diary_thread_initial_message(&page_url);
         let forum_post = CreateForumPost::new(date_str, initial_message);
@@ -705,7 +743,8 @@ impl Handler {
             .await
             .context("Failed to create forum post")?;
 
-        self.ensure_close_and_new_button(&ctx.http, thread.id).await?;
+        self.ensure_close_and_new_button(&ctx.http, thread.id)
+            .await?;
 
         info!(
             thread_id = thread.id.get(),
@@ -713,7 +752,6 @@ impl Handler {
             "Created new diary thread"
         );
 
-        // データベースに保存
         let new_entry = DiaryEntry {
             thread_id: thread.id.get(),
             page_id: page_id.clone(),
@@ -723,7 +761,6 @@ impl Handler {
         };
         self.diary_store.insert(&new_entry).await?;
 
-        // 新しいスレッドにメンションを送信
         let mention_message = CreateMessage::new().content(format!(
             "新しい日報スレッドを作成しました: <#{}>",
             thread.id.get()
@@ -732,6 +769,18 @@ impl Handler {
             .send_message(&ctx.http, mention_message)
             .await
             .context("Failed to send mention message")?;
+
+        let edit = EditThread::new().archived(true).locked(true);
+        channel_id
+            .edit_thread(&ctx.http, edit)
+            .await
+            .context("Failed to close thread after sending mention message")?;
+
+        info!(
+            old_thread_id = channel_id.get(),
+            new_thread_id = thread.id.get(),
+            "Diary thread closed by button"
+        );
 
         Ok(())
     }

--- a/crates/kgd/src/discord.rs
+++ b/crates/kgd/src/discord.rs
@@ -4,10 +4,11 @@ use anyhow::{Context as _, Result};
 use chrono::Timelike;
 use serenity::{
     all::{
-        ChannelId, ChannelType, CommandInteraction, ComponentInteraction, CreateActionRow,
-        CreateButton, CreateCommand, CreateCommandOption, CreateEmbed, CreateForumPost,
-        CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditThread,
-        GatewayIntents, Http, Message, MessageUpdateEvent, ReactionType,
+        ActionRowComponent, ButtonKind, ChannelId, ChannelType, CommandInteraction,
+        ComponentInteraction, CreateActionRow, CreateButton, CreateCommand, CreateCommandOption,
+        CreateEmbed, CreateForumPost, CreateInteractionResponse,
+        CreateInteractionResponseMessage, CreateMessage, EditThread, GatewayIntents, GetMessages,
+        Http, Message, MessageUpdateEvent, ReactionType,
     },
     async_trait,
     builder::CreateEmbedFooter,
@@ -29,6 +30,8 @@ use crate::{
     version,
     wol::send_wol_packet,
 };
+
+const DIARY_CLOSE_AND_NEW_BUTTON_ID: &str = "diary_close_and_new";
 
 /// Discord イベントを処理するハンドラー。
 #[derive(Clone)]
@@ -477,6 +480,8 @@ impl Handler {
                 .await
                 .context("スレッドのロック解除に失敗しました")?;
 
+            self.ensure_close_and_new_button(&ctx.http, thread_id).await?;
+
             info!(
                 date = %date,
                 thread_id = entry.thread_id,
@@ -524,6 +529,8 @@ impl Handler {
             .context("フォーラムスレッドの作成に失敗しました")?;
 
         // 紐付け情報を保存
+        self.ensure_close_and_new_button(&ctx.http, thread.id).await?;
+
         let entry = DiaryEntry {
             thread_id: thread.id.get(),
             page_id,
@@ -698,6 +705,8 @@ impl Handler {
             .await
             .context("Failed to create forum post")?;
 
+        self.ensure_close_and_new_button(&ctx.http, thread.id).await?;
+
         info!(
             thread_id = thread.id.get(),
             page_id = %page_id,
@@ -790,11 +799,31 @@ impl Handler {
 
         Ok(())
     }
+
+    async fn ensure_close_and_new_button(&self, http: &Http, thread_id: ChannelId) -> Result<()> {
+        let messages = thread_id
+            .messages(http, GetMessages::new().limit(10))
+            .await
+            .context("Failed to fetch thread messages to inspect close button")?;
+
+        if messages.iter().any(message_has_close_and_new_button) {
+            return Ok(());
+        }
+
+        self.send_auto_close_button(http, thread_id).await?;
+
+        info!(
+            thread_id = thread_id.get(),
+            "Sent fallback close-and-new button message"
+        );
+
+        Ok(())
+    }
 }
 
 /// クローズ&新規作成ボタンの ActionRow を作成する。
 fn create_close_and_new_action_row() -> CreateActionRow {
-    let button = CreateButton::new("diary_close_and_new")
+    let button = CreateButton::new(DIARY_CLOSE_AND_NEW_BUTTON_ID)
         .label("クローズして新しい日報を作成")
         .style(serenity::all::ButtonStyle::Primary);
     CreateActionRow::Buttons(vec![button])
@@ -805,6 +834,22 @@ fn create_diary_thread_initial_message(page_url: &str) -> CreateMessage {
     CreateMessage::new()
         .content(format!("Notion: {}", page_url))
         .components(vec![create_close_and_new_action_row()])
+}
+
+fn message_has_close_and_new_button(message: &Message) -> bool {
+    message.components.iter().any(|row| {
+        row.components.iter().any(|component| {
+            matches!(
+                component,
+                ActionRowComponent::Button(button)
+                    if matches!(
+                        &button.data,
+                        ButtonKind::NonLink { custom_id, .. }
+                            if custom_id == DIARY_CLOSE_AND_NEW_BUTTON_ID
+                    )
+            )
+        })
+    })
 }
 
 /// サーバーステータスをDiscordチャンネルに通知するための構造体。


### PR DESCRIPTION
## 概要
- 日報スレッドの初回メッセージに close-and-new ボタンを付与するようにした
- 既存の日報スレッドを `/diary new` で再利用する際、再オープンに失敗してもスレッド案内へフォールバックするようにした
- close-and-new ボタン押下時は、今日の最新スレッドを判定し、最新なら新規作成せず案内するようにした
- close-and-new で新規作成する場合は、元スレッドへの通知後に最後の1回だけクローズするようにした
- ボタン欠落時の補完送信を追加して、初回メッセージや再利用フローでボタンが見えないケースを減らした

## 動作変更
- 今日のスレッド自身で close-and-new ボタンを押した場合は「このスレッドが今日の最新の日報です」と案内する
- 今日の別スレッドがすでに存在する場合は、その最新スレッドを案内する
- `/diary new` で既存スレッドの再オープンに失敗した場合でも、コマンド自体は失敗させず既存スレッドへの案内にフォールバックする

## 確認
- `just validate`
- `cargo test -p kgd diary -- --nocapture`
- `just machete`
- `just deny` はローカルの cargo registry 展開時に `os error 5` で失敗するため未通過

Closes #58

Co-authored-by: Codex