### PR TITLE
RUSTSEC-2026-0049 を一時的に ignore する

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # notion-client のアップデートを待つ
 # image crate の依存関係 (rav1e -> paste) がメンテナンス終了
 # image crate のアップデートを待つ
-ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436"]
+ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0049"]
 
 # Licenses check - checks for allowed licenses
 # コピーレフト（伝搬性のある）ライセンスは許可しない


### PR DESCRIPTION
## 概要
`cargo deny` の一時対応として、`RUSTSEC-2026-0049` を `deny.toml` の ignore に追加します。

## 背景
- `serenity 0.12.5` 側の依存経路で `rustls-webpki 0.102.8` が残る
- `reqwest 0.11.27` 側の依存経路で `rustls-webpki 0.101.7` が残る
- `serenity` の公開最新版は現時点でも `0.12.5` で、単純な依存更新だけでは解消できなかった
- バックエンド変更で回避する案は確認できたが、動作差分のリスクがあるため採用していない

## 変更内容
- `deny.toml` の advisory ignore に `RUSTSEC-2026-0049` を追加

## 確認
- `just deny`
- `cargo check -p kgd`

Refs #65

Co-authored-by: Codex <codex@openai.com>