### PR TITLE
日報の自動クローズチェックのズレを減らし、重複通知を防ぐ

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -84,10 +84,6 @@ forum_channel_id = 123456789012345678
 # The button will only be sent after this hour in the configured timezone
 # auto_close_hour = 8
 
-# Interval for checking threads that need auto-close (default: 1h)
-# Format: "30s", "5m", "1h", "2h", etc.
-# auto_close_interval = "1h"
-
 # OGP metadata fetching for bookmark blocks (default: enabled)
 # When enabled, the bot will fetch Open Graph metadata (title, description)
 # from bookmarked URLs and add them as captions in Notion.

--- a/crates/kgd/src/config.rs
+++ b/crates/kgd/src/config.rs
@@ -147,9 +147,6 @@ pub struct DiaryConfig {
     /// 自動クローズの確認メッセージを送信する時刻（時）（デフォルト: 8）
     #[serde(default = "default_auto_close_hour")]
     pub auto_close_hour: u32,
-    /// 自動クローズのチェック間隔（デフォルト: 1時間）
-    #[serde(default = "default_auto_close_interval", with = "humantime_serde")]
-    pub auto_close_interval: Duration,
     /// OGP メタデータ取得を有効にするか（デフォルト: true）
     #[serde(default = "default_ogp_enabled")]
     pub ogp_enabled: bool,
@@ -217,10 +214,6 @@ fn default_auto_close_hour() -> u32 {
     8
 }
 
-fn default_auto_close_interval() -> Duration {
-    Duration::from_secs(3600) // 1 hour
-}
-
 fn default_ogp_enabled() -> bool {
     true
 }
@@ -272,7 +265,6 @@ mod tests {
                 default_convert_to: vec!["link".to_string()],
                 auto_close_enabled: false,
                 auto_close_hour: 8,
-                auto_close_interval: Duration::from_secs(3600),
                 ogp_enabled: true,
                 ogp_timeout: Duration::from_secs(10),
             },

--- a/crates/kgd/src/discord.rs
+++ b/crates/kgd/src/discord.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::{Context as _, Result};
-use chrono::Timelike;
+use chrono::{NaiveDate, Timelike};
 use serenity::{
     all::{
         ActionRowComponent, ButtonKind, ChannelId, ChannelType, CommandInteraction,
@@ -17,7 +17,7 @@ use serenity::{
     model::id::MessageId,
     prelude::*,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 use tracing::{error, info, warn};
 
 use crate::{
@@ -42,6 +42,8 @@ pub struct Handler {
     diary_store: DiaryStore,
     /// Notion クライアント
     notion_client: Arc<NotionClient>,
+    /// 自動クローズ通知を送信済みの日付（タイムゾーン基準）
+    last_auto_close_notification_date: Arc<Mutex<Option<NaiveDate>>>,
 }
 
 #[async_trait]
@@ -794,10 +796,19 @@ impl Handler {
         let timezone = &self.config.diary.timezone;
         let now = chrono::Utc::now().with_timezone(timezone);
         let today = today_in_timezone(timezone);
+        let today_local = now.date_naive();
 
         // 指定された時刻以降かチェック
         if now.hour() < self.config.diary.auto_close_hour {
             return Ok(());
+        }
+
+        {
+            let last_auto_close_notification_date =
+                self.last_auto_close_notification_date.lock().await;
+            if last_auto_close_notification_date.is_some_and(|date| date == today_local) {
+                return Ok(());
+            }
         }
 
         // 最新のエントリのみを取得
@@ -829,6 +840,7 @@ impl Handler {
 
         // ボタン付きメッセージを送信
         self.send_auto_close_button(http, thread_id).await?;
+        *self.last_auto_close_notification_date.lock().await = Some(today_local);
 
         info!(thread_id = entry.thread_id, "Sent auto-close button");
 
@@ -963,6 +975,7 @@ pub async fn run(config: Config, status_rx: mpsc::Receiver<Vec<ServerStatus>>) -
         config: config.clone(),
         diary_store,
         notion_client,
+        last_auto_close_notification_date: Arc::new(Mutex::new(None)),
     };
 
     let mut client = Client::builder(&config.discord.token, intents)
@@ -986,7 +999,7 @@ pub async fn run(config: Config, status_rx: mpsc::Receiver<Vec<ServerStatus>>) -
     if config.diary.auto_close_enabled {
         let auto_close_handler = handler.clone();
         let auto_close_http = client.http.clone();
-        let auto_close_interval = config.diary.auto_close_interval;
+        let auto_close_interval = Duration::from_secs(60);
         tokio::spawn(async move {
             run_auto_close_checker(auto_close_handler, auto_close_http, auto_close_interval).await;
         });


### PR DESCRIPTION
## 概要
- 日報の自動クローズチェックを設定値ではなく 1 分固定で実行するように変更
- その日付ですでに自動クローズ通知を送っている場合は、同日の再通知をスキップ
- 参照されなくなった `diary.auto_close_interval` を `config` と設定例から削除
- `master` からの差分をできるだけ小さく保ち、既存の Discord 自動クローズ処理の流れの中で対応

## 動作確認
- `cargo check -p kgd`
- `cargo test -p kgd`

Closes #59