### PR TITLE
Add devcontainer development environment #72

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+# kgd 開発用 devcontainer イメージ
+# heif-sys が libheif をソースからビルドするため、ビルド依存を一式入れる
+FROM rust:bookworm
+
+# システム依存ライブラリ
+# - bindgen 用: libclang-dev
+# - libheif ビルド/リンク用: cmake, ninja-build, libde265/x265/aom/webp/jpeg, zlib
+# - reqwest(OpenSSL) 用: libssl-dev, pkg-config
+# - DB 操作の利便性: postgresql-client
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    git \
+    cmake \
+    ninja-build \
+    libclang-dev \
+    libde265-dev \
+    libx265-dev \
+    libaom-dev \
+    libwebp-dev \
+    zlib1g-dev \
+    libjpeg-dev \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# rustfmt / clippy を確実に入れる
+RUN rustup component add rustfmt clippy
+
+# 開発ワークフローで使うツール
+# (--locked で Cargo.lock 準拠の互換バージョンを使う)
+RUN cargo install --locked just cargo-deny cargo-machete

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "kgd",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "dev",
+  "workspaceFolder": "/workspaces/kgd",
+  "postCreateCommand": "git config --global --add safe.directory /workspaces/kgd",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb"
+      ],
+      "settings": {
+        "rust-analyzer.check.command": "clippy"
+      }
+    }
+  },
+  "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,41 @@
+# devcontainer 用の compose 定義
+# 本番の compose.yml とは独立。DB はコンテナ内ネットワークでのみ利用し、
+# ホストの 5432(本番 kgd-db)と衝突しないようポート公開しない。
+services:
+  dev:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      # ワークスペースをマウント
+      - ..:/workspaces/kgd:cached
+      # ビルドキャッシュは名前付きボリュームに分離(ホストの target/ と混ざらない)
+      - cargo-registry:/usr/local/cargo/registry
+      - target-cache:/workspaces/kgd/target
+    environment:
+      # sqlx / diary 機能が参照する DB 接続先
+      DATABASE_URL: postgres://kgd:kgd@db:5432/kgd
+    command: sleep infinity
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: kgd
+      POSTGRES_PASSWORD: kgd
+      POSTGRES_DB: kgd
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kgd"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  cargo-registry:
+  target-cache:
+  pgdata:


### PR DESCRIPTION
Closes #72

## 概要

ホスト(Raspberry Pi / aarch64)で直接ビルドするには、`heif-sys` が libheif をソースからビルドするため多くのシステム依存(`libclang-dev`, `cmake`, `ninja-build`, `libde265/x265/aom/webp/jpeg-dev`, `zlib1g-dev`, `libssl-dev` 等)を apt で入れる必要があり `sudo` も要る。devcontainer に閉じ込めて環境差をなくす。

## 変更内容

- **`.devcontainer/Dockerfile`** — `rust:bookworm` ベース。libheif ビルドに必要なシステム依存 + rustfmt/clippy + `just`/`cargo-deny`/`cargo-machete` を同梱
- **`.devcontainer/docker-compose.yml`** — `dev` サービス + `db`(postgres:17)。本番の 5432 と衝突しないようポート非公開、`DATABASE_URL` を `db` ホスト向けに設定、cargo registry / target は名前付きボリュームに分離
- **`.devcontainer/devcontainer.json`** — rust-analyzer(clippy 連携)/even-better-toml/lldb 拡張、`git safe.directory` を `postCreateCommand` で設定

## 確認済み

- コンテナ内で `cargo build --bin kgd`(libheif のソースビルド込み)が完走
- コンテナ内で `just validate`(fmt / check / clippy)が通過

## メモ

- diary 機能を使う場合、`config.toml` の `diary.database_url` を `postgres://kgd:kgd@db:5432/kgd`(`localhost` ではなく `db`)にする
- bot のライブ起動には Discord トークン(Message Content Intent を有効化)が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)