### PR TITLE
Isolate compose.local from production on the same host #74

### DIFF
--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,11 +1,25 @@
 # ローカル開発用のオーバーライド
 # 使用方法: docker compose -f compose.yml -f compose.local.yml up --build
 # または: just compose-local
+#
+# 本番(compose.yml 単体)と同一ホスト上で同時に動かしても衝突しないよう、
+# project 名・コンテナ名・DB 公開ポートを分離している。
+# kgd は WoL のため network_mode: host を継承するので、DB へは
+# localhost:5433(本番 DB は 5432)で接続する。config.toml の
+# diary.database_url を postgres://kgd:kgd@localhost:5433/kgd に合わせること。
+
+name: kgd-local
 
 services:
   kgd:
     image: kgd:local
+    container_name: kgd-local
     build:
       context: .
       dockerfile: Dockerfile
       target: local
+
+  db:
+    container_name: kgd-db-local
+    ports: !override
+      - "5433:5432"


### PR DESCRIPTION
## 概要

compose.local(just compose-local)を、本番(compose.yml 単体)と同一ホスト上で同時に起動しても衝突しないように分離する。

Closes #74

## 背景

project 名がどちらも kgd(ディレクトリ名由来)で、container_name と DB ポート 5432 も重複していたため、本番 bot を動かしたままローカルで起動確認しようとすると衝突していた(最悪、本番コンテナを再作成してしまう恐れ)。

## 変更内容

compose.local.yml にオーバーライドを追加。

- name: kgd-local … project 名を分離(volume / network も kgd-local_* に自動分離)
- container_name: kgd-local / kgd-db-local … コンテナ名を分離
- db の ports に !override で 5433:5432 を指定 … DB 公開ポートを分離(!override でベースの 5432 を置換)

kgd は WoL のため network_mode: host を継承するので、DB へは localhost:5433 で接続する(config.toml の diary.database_url を postgres://kgd:kgd@localhost:5433/kgd に合わせる旨をコメントに明記)。

## 確認済み

Raspberry Pi (aarch64) 上で、本番 bot を稼働させたまま以下を確認。

- docker compose -f compose.yml -f compose.local.yml build で local ターゲットのビルド成功(libheif をソースビルド)
- up で kgd-local / kgd-db-local が別ポート(5433)で起動、本番に影響なし
- ログで Bot connected / DB 接続(Diary periodic tasks started)/ Slash commands 登録を確認
- down -v で撤去後、本番コンテナが無事稼働継続していることを確認

## 補足

- 当初 #72(devcontainer)として着手したが、目的は Docker 上でアプリを起動することであり、既存の compose.local を活かす方針に切り替えた。#72・PR #73 は対応外としてクローズ済み。
- 変更は YAML のみで Rust コードに変更なし。

このPRは Claude Code により作成。