### PR TITLE
cargo-deny の advisory 失敗を修正 (rustls-webpki / core2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,11 +277,11 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -580,15 +580,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1693,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1711,8 +1702,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.12",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2083,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -2119,6 +2110,15 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -2760,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -3030,7 +3030,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3067,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3860,16 +3860,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5022,12 +5022,6 @@ checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
@@ -5043,18 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
 dependencies = [
- "zune-core 0.5.1",
+ "zune-core",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,18 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # notion-client のアップデートを待つ
 # image crate の依存関係 (rav1e -> paste) がメンテナンス終了
 # image crate のアップデートを待つ
-ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0049"]
+ignore = [
+    "RUSTSEC-2025-0134",
+    "RUSTSEC-2024-0436",
+    "RUSTSEC-2026-0049",
+    # rustls-webpki 0.102.x の脆弱性。修正版は >=0.103.12 だが、
+    # serenity 0.12.5 -> tokio-tungstenite 0.21 -> rustls 0.22.4 が
+    # rustls-webpki 0.102.x を固定しており cargo update では更新できない。
+    # 0.102.x 系に修正版が存在しないため、serenity 側の上流更新を待つ。
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102.x (serenity 0.12.5 -> rustls 0.22.4 経由)。0.102.x 系に修正版なし、上流更新待ち" },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102.x (serenity 0.12.5 -> rustls 0.22.4 経由)。0.102.x 系に修正版なし、上流更新待ち" },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102.x (serenity 0.12.5 -> rustls 0.22.4 経由)。0.102.x 系に修正版なし、上流更新待ち" },
+]
 
 # Licenses check - checks for allowed licenses
 # コピーレフト（伝搬性のある）ライセンスは許可しない

--- a/deny.toml
+++ b/deny.toml
@@ -12,22 +12,75 @@ all-features = true
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# notion-client の依存関係 (reqwest v0.11) が使用している rustls-pemfile はメンテナンス終了
-# notion-client のアップデートを待つ
-# image crate の依存関係 (rav1e -> paste) がメンテナンス終了
-# image crate のアップデートを待つ
-ignore = [
-    "RUSTSEC-2025-0134",
-    "RUSTSEC-2024-0436",
-    "RUSTSEC-2026-0049",
-    # rustls-webpki 0.102.x の脆弱性。修正版は >=0.103.12 だが、
-    # serenity 0.12.5 -> tokio-tungstenite 0.21 -> rustls 0.22.4 が
-    # rustls-webpki 0.102.x を固定しており cargo update では更新できない。
-    # 0.102.x 系に修正版が存在しないため、serenity 側の上流更新を待つ。
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102.x (serenity 0.12.5 -> rustls 0.22.4 経由)。0.102.x 系に修正版なし、上流更新待ち" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102.x (serenity 0.12.5 -> rustls 0.22.4 経由)。0.102.x 系に修正版なし、上流更新待ち" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102.x (serenity 0.12.5 -> rustls 0.22.4 経由)。0.102.x 系に修正版なし、上流更新待ち" },
-]
+
+# paste はメンテナンス終了 (脆弱性ではなく未保守の通知)。
+# 依存経路: paste -> rav1e -> ravif -> image -> heif -> kgd。
+# 画像 (HEIC 等) 変換のためのビルド時 proc-macro として利用されるのみで、
+# 実行時のセキュリティ影響はない。修正版は存在せず、image / rav1e 側の上流更新を待つ。
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0436"
+reason = "paste はメンテナンス終了 (未保守の通知のみで脆弱性ではない)。image -> rav1e 経由で引き込まれるビルド時 proc-macro で実行時影響なし。修正版なし、上流更新待ち"
+
+# rustls-pemfile はメンテナンス終了 (脆弱性ではなく未保守の通知)。
+# 依存経路: rustls-pemfile -> reqwest 0.11 -> notion-client -> kgd。
+# notion-client が古い reqwest 0.11 を使用しているため引き込まれる。
+# 既知の脆弱性はなく、notion-client が reqwest を更新するのを待つ。
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0134"
+reason = "rustls-pemfile はメンテナンス終了 (未保守の通知のみで脆弱性ではない)。notion-client -> reqwest 0.11 経由で引き込まれる。既知の脆弱性なし、notion-client の更新待ち"
+
+# rustls-webpki 0.102.x の CRL 照合ロジックの不具合。
+# 依存経路: rustls-webpki 0.102.8 -> rustls 0.22.4 -> tokio-tungstenite 0.21
+#   -> serenity 0.12.5 -> kgd (Discord 接続の TLS クライアント)。
+# 本プロジェクトは CRL ベースの失効確認を構成しておらず本不具合には到達しない。
+# また悪用には信頼された発行局の侵害が必要で実質的な影響は限定的。
+# 0.102.x 系に修正版がなく、serenity が rustls 0.22.4 を固定しているため上流更新待ち。
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0049"
+reason = """
+rustls-webpki 0.102.x の CRL distributionPoint 照合ロジックの不具合。
+依存経路: rustls-webpki 0.102.8 -> rustls 0.22.4 -> tokio-tungstenite 0.21 -> serenity 0.12.5 -> kgd (Discord 接続の TLS クライアント)。
+本プロジェクトは CRL ベースの失効確認を構成しておらず本不具合には到達しない。悪用にも信頼された発行局の侵害が必要で実質的な影響は限定的。
+0.102.x 系に修正版がなく serenity が rustls 0.22.4 を固定しているため、serenity 側の上流更新を待つ。
+"""
+
+# rustls-webpki 0.102.x で URI 名の name constraints が無視され受理される不具合。
+# 依存経路は RUSTSEC-2026-0049 と同じ (serenity -> rustls 0.22.4)。
+# 発火には署名検証後の誤発行証明書が必要で、既知の正規 CA に接続する
+# クライアント用途 (Discord) では実質的な影響はない。
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0098"
+reason = """
+rustls-webpki 0.102.x で URI 名の name constraints が無視され受理される不具合。
+依存経路: rustls-webpki 0.102.8 -> rustls 0.22.4 -> tokio-tungstenite 0.21 -> serenity 0.12.5 -> kgd (Discord 接続の TLS クライアント)。
+発火には署名検証後の誤発行証明書が必要で、既知の正規 CA に接続するクライアント用途では実質的な影響はない。
+0.102.x 系に修正版がなく serenity が rustls 0.22.4 を固定しているため、serenity 側の上流更新を待つ。
+"""
+
+# rustls-webpki 0.102.x でワイルドカード名証明書に対し name constraints が
+# 誤って受理される不具合。依存経路は RUSTSEC-2026-0049 と同じ。
+# 発火には誤発行証明書が必要で、クライアント用途 (Discord) では実質的な影響はない。
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0099"
+reason = """
+rustls-webpki 0.102.x でワイルドカード名証明書に対し name constraints が誤って受理される不具合。
+依存経路: rustls-webpki 0.102.8 -> rustls 0.22.4 -> tokio-tungstenite 0.21 -> serenity 0.12.5 -> kgd (Discord 接続の TLS クライアント)。
+発火には誤発行証明書が必要で、既知の正規 CA に接続するクライアント用途では実質的な影響はない。
+0.102.x 系に修正版がなく serenity が rustls 0.22.4 を固定しているため、serenity 側の上流更新を待つ。
+"""
+
+# rustls-webpki 0.102.x の CRL パースで到達可能な panic。
+# 依存経路は RUSTSEC-2026-0049 と同じ。
+# advisory 記載の通り CRL を使用しないアプリケーションは影響を受けず、
+# 本プロジェクトは CRL を使用しないため影響なし。
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0104"
+reason = """
+rustls-webpki 0.102.x の CRL パースで到達可能な panic。
+依存経路: rustls-webpki 0.102.8 -> rustls 0.22.4 -> tokio-tungstenite 0.21 -> serenity 0.12.5 -> kgd (Discord 接続の TLS クライアント)。
+advisory 記載の通り CRL を使用しないアプリケーションは影響を受けず、本プロジェクトは CRL を使用しないため影響なし。
+0.102.x 系に修正版がなく serenity が rustls 0.22.4 を固定しているため、serenity 側の上流更新を待つ。
+"""
 
 # Licenses check - checks for allowed licenses
 # コピーレフト（伝搬性のある）ライセンスは許可しない


### PR DESCRIPTION
## 概要

CI の cargo deny check が複数の RUSTSEC advisory で失敗していたため修正する。

## 検証と対応

### cargo update で解消できたもの

- core2 (RUSTSEC-2026-0105, 全バージョン yank): cargo update で bitstream-io 4.9.0 から 4.10.0 / image 0.25.9 から 0.25.10 になり、依存ツリーから core2 が除去された (no_std_io2 に置換)。
- rustls-webpki 0.103.9 から 0.103.13: cargo update で RUSTSEC 修正版に更新。

### cargo update で解消できず deny.toml で除外したもの

serenity 0.12.5 が tokio-tungstenite 0.21 経由で rustls 0.22.4 を固定しており、rustls-webpki 0.102.x が引き込まれる。0.102.x 系に修正版が存在しないため cargo update では更新できず、serenity 側の上流更新を待つ。いずれも Discord 接続の TLS クライアント経路で、本プロジェクトの利用形態では実質的な影響は限定的と判断し、reason 付きで除外した。

- RUSTSEC-2026-0049: CRL 照合ロジックの不具合。本プロジェクトは CRL ベースの失効確認を構成していないため到達しない。
- RUSTSEC-2026-0098 / 0099: name constraints の検証不備。発火には誤発行証明書が前提で、正規 CA に接続するクライアント用途では影響なし。
- RUSTSEC-2026-0104: CRL パースで到達可能な panic。CRL 未使用のため影響なし。

### deny.toml の整理

- ignore を配列形式から [[advisories.ignore]] のテーブル形式に書き直し、各 advisory に本プロジェクトでの影響有無を含む reason を付与した。
- 既存 ignore も再調査した。RUSTSEC-2024-0436 (paste) と RUSTSEC-2025-0134 (rustls-pemfile) はいずれも未保守の通知で脆弱性ではなく、前者は image から rav1e 経由のビルド時 proc-macro、後者は notion-client から reqwest 0.11 経由で引き込まれる。RUSTSEC-2026-0049 は元コメントが paste としていたが、実際は rustls-webpki 0.102.x の脆弱性だったため記述を修正した。
- ignore を空にして cargo deny を実行し、6 件すべてが現在も発火することを確認した。不要になった ignore はない。

## 確認

- cargo deny check: advisories ok, bans ok, licenses ok, sources ok
- cargo check --all-targets: 成功
- cargo fmt --check / cargo machete: 問題なし