### PR TITLE
テストカバレッジを Codecov で可視化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,50 @@ jobs:
       - name: check source
         run: just ci
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            ninja-build \
+            libclang-dev \
+            libde265-dev \
+            libx265-dev \
+            libaom-dev \
+            libwebp-dev \
+            zlib1g-dev \
+            libjpeg-dev \
+            libnuma-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage (lcov)
+        run: cargo llvm-cov --all --workspace --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build:
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage (lcov)
-        run: cargo llvm-cov --all --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/Justfile
+++ b/Justfile
@@ -43,7 +43,7 @@ test:
 # Run tests with coverage (HTML report; requires cargo-llvm-cov)
 cov:
     @echo "Running coverage..."
-    cargo llvm-cov --all --workspace --html
+    cargo llvm-cov --workspace --html
 
 # Build release binary
 build:

--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,11 @@ test:
     @echo "Running tests..."
     cargo test --all
 
+# Run tests with coverage (HTML report; requires cargo-llvm-cov)
+cov:
+    @echo "Running coverage..."
+    cargo llvm-cov --all --workspace --html
+
 # Build release binary
 build:
     @echo "Building release binary..."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kgd
 
+[![codecov](https://codecov.io/gh/ekuinox/kgd/graph/badge.svg)](https://codecov.io/gh/ekuinox/kgd)
+
 ekuinox 自身のためにいろいろやってもらう bot 的な何か
 
 Discord Bot として機能して、ローカルのサーバーの起動や Notion のデータベース管理などを行いたい
@@ -25,4 +27,15 @@ just run
 
 # ローカルで docker compose を使って起動する
 just compose-local
+```
+
+## テストカバレッジ
+
+カバレッジは [Codecov](https://codecov.io/gh/ekuinox/kgd) で確認できる（PR には自動でカバレッジコメントが付く）。
+
+ローカルで HTML レポートを生成する場合:
+
+```bash
+cargo install cargo-llvm-cov  # 初回のみ
+just cov
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+
+ignore:
+  - "crates/heif-sys/**"
+  - "crates/heif/**"


### PR DESCRIPTION
## 概要

テストカバレッジを GitHub 上で確認できるようにする。リポジトリページ（README バッジ）で全体カバレッジを、PR では Codecov の自動コメントで差分カバレッジを確認できる。

## 変更内容

- `.github/workflows/build.yml`: cargo-llvm-cov でカバレッジを計測する coverage ジョブを追加し、codecov/codecov-action@v5 で lcov をアップロード。既存の check / build ジョブは無変更。
- `codecov.yml`: PR コメントの挙動、カバレッジ目標（当面は informational で CI を落とさない）、heif 系 crate（C FFI 中心）の除外を設定。
- `Justfile`: ローカルで HTML レポートを生成する just cov レシピを追加。
- `README.md`: Codecov バッジとカバレッジ確認手順を追加。

## マージ前に必要な作業

- Codecov（ https://codecov.io ）に GitHub でログインし `ekuinox/kgd` を有効化する。
- レート制限回避のため、Codecov で取得したトークンを GitHub の Secrets に `CODECOV_TOKEN` として登録する（公開リポジトリのため未登録でも動作する）。

## 確認方法

- この PR の coverage ジョブが成功し、Codecov の bot コメントが付くこと。
- master マージ後に README バッジが実際の数値を表示すること。
- ローカルでは `cargo install cargo-llvm-cov` 後に `just cov` で HTML レポートが生成されること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)