### PR TITLE
ADR-0002 に検討した代替案 (RPIT/AFIT・DIコンテナ) を追記

### DIFF
--- a/docs/adr/0002-ports-with-dynamic-dispatch.md
+++ b/docs/adr/0002-ports-with-dynamic-dispatch.md
@@ -28,3 +28,27 @@ mockall との併用にあたり、trait のメソッドはジェネリクスを
 
 - テストでは `MockNotionApi` などの自動生成モックで呼び出し回数・順序・引数を検証できる
 - Composition Root (bootstrap) で `Arc::new(実装) as Arc<dyn ポート>` と組み立てるだけで配線できる
+
+## 検討した代替案 (2026-06-12 追記)
+
+### RPIT / AFIT (`async fn in trait`) で async-trait を外す → 不採用
+
+AFIT / RPITIT は Rust 1.92 で安定しているが **`dyn` 互換ではない**ため、
+`Arc<dyn ポート>` を保ったまま async-trait を外すことはできない。外す道は次の2つだけで、いずれも純損:
+
+- ジェネリクス全面移行 → 本 ADR で却下済み。集約点の `DiscordController` は
+  下位ポートの和集合で型パラメータが 8 個になり、serenity の `EventHandler` 実装が
+  複数ファイルに分かれるため 8 個の where 句が全 impl ブロックに反復する。
+  組み立て側は型推論が効くが、定義側の恒常的なノイズに見合う便益がない。
+- `dynosaur` 等で AFIT + dyn ラッパーを生成 → `#[cfg_attr(test, mockall::automock)]` が
+  AFIT 未対応のため、全ポートのテストモック基盤を作り直す必要があり過大。
+
+async-trait の実体は呼び出しごとの `Box` 確保 1 回で、IO バウンドな bot では無視できる。
+なお `Clock` / `ImageConverter` / `WolSender` は同期メソッドのため元から async-trait 不使用。
+
+### DI コンテナ (shaku 等) の導入 → 不採用
+
+bootstrap の手動コンストラクタ注入で配線は十分明快。コンテナは `Component` / `Interface`
+derive や `module!` マクロで boilerplate を増やし、配線の見通しをむしろ下げる。
+Rust では手動コンストラクタ注入が最も素直な DI である。将来 bootstrap が肥大化した場合は、
+コンテナ導入ではなくヘルパー関数への分割で対処する。


### PR DESCRIPTION
## 概要

「リポジトリ抽象化の async-trait を RPIT で辞められないか」「DI コンテナで依存性注入を改善できないか」を検討した結果、いずれも現状維持が妥当と判断した。同じ問いの再燃を防ぐため、ADR-0002 に却下した代替案とその理由を追記する。

## 変更内容

- `docs/adr/0002-ports-with-dynamic-dispatch.md` に「検討した代替案 (2026-06-12 追記)」節を追加（既存の「決定」「結果」節は不変）

### 記録した結論

- **RPIT / AFIT で async-trait を外す案 → 不採用**: AFIT/RPITIT は `dyn` 非互換のため `Arc<dyn ポート>` と両立しない。ジェネリクス全面移行（`DiscordController` が型パラメータ8個）か `dynosaur`（mockall 非対応でテスト基盤作り直し）のいずれも純損。`Box` 確保コストは IO バウンドな bot では無視できる。
- **DI コンテナ (shaku 等) 導入案 → 不採用**: 手動コンストラクタ注入で配線は十分明快。肥大化時はヘルパー関数分割で対処する。

## 検証

ドキュメントのみの変更のため動作検証は不要。既存節を書き換えていないことを差分で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)